### PR TITLE
Fix renewal config

### DIFF
--- a/accounts.js
+++ b/accounts.js
@@ -68,7 +68,7 @@ class Accounts {
       return Promise.all(keys.map(key => {
         return s3.getObjectAsync({ Bucket, Key: path.join(accountDir, `${key}.json`) })
           .then(item => {
-            const body = item.Body
+            const body = item.Body.toString('utf8')
             try {
               files[key] = JSON.parse(body)
             } catch (error) {

--- a/configs.js
+++ b/configs.js
@@ -63,12 +63,10 @@ class Configs {
           })
         }
 
-        checkpoints = pyobj.checkpoints
         agreeTos = (agreeTos || pyobj.tos) && true
         email = email || pyobj.email
         domains = domains || pyobj.domains
 
-        webrootPath = webrootPath || pyobj.webrootPath[0];
         server = server || acmeDiscoveryUrl || pyobj.server;
 
         certPath = certPath || pyobj.cert;
@@ -76,10 +74,9 @@ class Configs {
         chainPath = chainPath || pyobj.chain;
         fullchainPath = fullchainPath || pyobj.fullchain;
 
-        rsaKeySize = args.rsaKeySize || pyobj.rsaKeySize;
-        http01Port = args.http01Port || pyobj.http01Port;
-        domainKeyPath = args.domainKeyPath || args.keyPath || pyobj.keyPath;
-        return writeRenewalConfig({
+        rsaKeySize = rsaKeySize || pyobj.rsaKeySize;
+        http01Port = http01Port || pyobj.http01Port;
+        return this.writeRenewalConfig({
           pyobj,
           domains,
           liveDir,

--- a/configs.js
+++ b/configs.js
@@ -108,7 +108,7 @@ class Configs {
       Bucket,
       Key: renewalPath
     })
-    .then(data => pyconf.parseAsync(data.Body))
+    .then(data => pyconf.parseAsync(data.Body.toString()))
     .catch(() => pyconf.parseAsync('checkpoints = -1'))
   }
 


### PR DESCRIPTION
`s3.getObjectAsync()` returns a `Buffer` object and there were several places that `.toString()` wasn't being called. Specifically in `Configs.checkAsync()`, which resulted in the renewal config never being updated. This change fixes that.